### PR TITLE
商品編集機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,6 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new]
+  before_action :set_item, only: [:show, :edit]
 
   def index
     @items = Item.all
@@ -19,12 +20,29 @@ class ItemsController < ApplicationController
   end
   
   def show
+    
+  end
+
+  def edit
+ 
+  end
+
+  def update
     @item = Item.find(params[:id])
+    if @item.update(item_params)
+      redirect_to root_path
+    else
+      render :edit
+    end
   end
 
   private
   def item_params
     params.require(:item).permit(:name, :description, :image, :category_id, :condition_id, :carriage_id, :area_id, :duration_id, :price).merge(user_id: current_user.id)
+  end
+
+  def set_item
+    @item = Item.find(params[:id])
   end
 
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -18,14 +18,7 @@ class ItemsController < ApplicationController
       render :new
     end
   end
-  
-  def show
-    
-  end
 
-  def edit
- 
-  end
 
   def update
     @item = Item.find(params[:id])

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -4,7 +4,7 @@
       = link_to image_tag('furima-logo-color.png' , size: '185x50'), "/"
     .items-sell-main
       %h2.items-sell-title 商品の情報を入力
-      = form_with local: true do |f|
+      = form_with model:@item, local: true do |f|
         .img-upload
           .weight-bold-text
             出品画像
@@ -12,81 +12,81 @@
           .click-upload
             %p
               クリックしてファイルをアップロード
-            = f.file_field :hoge
+            = f.file_field :image
         .new-items
           .weight-bold-text
             商品名
             %span.indispensable 必須
-          = f.text_area :hoge, class:"items-text", placeholder:"商品名（必須 40文字まで)", maxlength:"40"
+          = f.text_area :name, class:"items-text", placeholder:"商品名（必須 40文字まで)", maxlength:"40", value: @item.name
           .items-explain
             .weight-bold-text
               商品の説明
               %span.indispensable 必須
-            = f.text_area :hoge, class:"items-text", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000"
+            = f.text_area :description, class:"items-text", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000", value: @item.description
         .items-detail
           .weight-bold-text 商品の詳細
           .form
             .weight-bold-text
               カテゴリー
               %span.indispensable 必須
-            = f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box"})
+            = f.collection_select(:category_id, Category.all, :id, :name, {prompt: @item.category.name}, {class:"select-box"})
             .weight-bold-text
               商品の状態
               %span.indispensable 必須
-            = f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box"})
+            = f.collection_select(:condition_id, Condition.all, :id, :name, {prompt: @item.condition.name}, {class:"select-box"})
         .items-detail
           .weight-bold-text.question-text
             %span 配送について
-            %a.question{:href => "#"} ?
+            = link_to "?", "#", class: "question" 
           .form
             .weight-bold-text
               配送料の負担
               %span.indispensable 必須
-            = f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box"})
+            = f.collection_select(:carriage_id, Carriage.all, :id, :name, {prompt: @item.carriage.name}, {class:"select-box"})
             .weight-bold-text
               発送元の地域
               %span.indispensable 必須
-            = f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box"})
+            = f.collection_select(:area_id, Area.all, :id, :name, {prompt: @item.area.name}, {class:"select-box"})
             .weight-bold-text
               発送までの日数
               %span.indispensable 必須
-            = f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box"})
+            = f.collection_select(:duration_id, Duration.all, :id, :name, {prompt: @item.duration.name}, {class:"select-box"})
         .sell-price
           .weight-bold-text.question-text
             %span
               販売価格
               %br>/
               (¥300〜9,999,999)
-            %a.question{:href => "#"} ?
+            = link_to "?", "#", class: "question"
           %div
             .price-content
               .price-text
                 %span 価格
                 %span.indispensable 必須
               %span.sell-yen ¥
-              = f.text_field :hoge, class:"price-input", placeholder:"例）300"
+              = f.text_field :price, class:"price-input", placeholder:"例）300"
             .price-content
               %span 販売手数料 (10%)
               %span
-                %span#add-tax-price>
+                %span#add-tax-price
                 円
             .price-content
               %span 販売利益
               %span
-                %span#profit>
+                %span#profit
                 円
         .caution
           %p.sentence
-            %a{:href => "#"} 禁止されている出品、
-            %a{:href => "#"} 行為
+            = link_to "禁止されている出品、", "#"
+            = link_to "行為", "#"
             を必ずご確認ください。
           %p.sentence
             またブランド品でシリアルナンバー等がある場合はご記載ください。
-            %a{:href => "#"} 偽ブランドの販売
+            = link_to "偽ブランドの販売", "#"
             は犯罪であり処罰される可能性があります。
           %p.sentence
             また、出品をもちまして
-            %a{:href => "#"} 加盟店規約
+            = link_to "加盟店規約", "#"
             に同意したことになります。
         .sell-btn-contents
           = f.submit "変更する" ,class:"sell-btn"
@@ -94,11 +94,11 @@
     %footer.items-sell-footer
       %ul.menu
         %li
-          %a{:href => "#"} プライバシーポリシー
+          = link_to "プライバシーポリシー", "#"
         %li
-          %a{:href => "#"} フリマ利用規約
+          = link_to "フリマ利用規約", "#"
         %li
-          %a{:href => "#"} 特定商取引に関する表記
+          = link_to "特定商取引に関する表記", "#"
       = link_to image_tag('furima-logo-color.png' , size: '185x50'), "/"
       %p.inc
         ©︎Furima,Inc.

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -68,12 +68,12 @@
             .price-content
               %span 販売手数料 (10%)
               %span
-                %span#add-tax-price>
+                %span#add-tax-price
                 円
             .price-content
               %span 販売利益
               %span
-                %span#profit>
+                %span#profit
                 円
         .caution
           %p.sentence

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -15,7 +15,7 @@
         (税込) 送料込み
     - if user_signed_in?
       - if current_user.id == @item.user.id
-        = link_to '商品の編集', "#", method: :get, class: "item-red-btn"
+        = link_to '商品の編集', edit_item_path(@item.id), method: :get, class: "item-red-btn"
         %p.or-text or
         = link_to '削除', "#", method: :delete, class:'item-destroy'
       - else


### PR DESCRIPTION
#WHAT
商品編集機能を実装

#WHY
商品内容を投稿者のみ変更できるようにするため。
元もの情報を入力欄に表示させた。
https://gyazo.com/c071e1e746cd4b05f5e6a25ddbb9c8f8